### PR TITLE
support relay `Node` interface

### DIFF
--- a/example_project/app/schema.py
+++ b/example_project/app/schema.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
 
 
 class Query(graphene.ObjectType):
+    node = relay.Node.Field()
     all_postal_codes = DjangoListField(PostalCodeType)
     all_developers = DjangoListField(DeveloperType)
     all_property_managers = DjangoListField(PropertyManagerType)

--- a/example_project/app/types.py
+++ b/example_project/app/types.py
@@ -213,6 +213,7 @@ class ApartmentType(DjangoObjectType):
             "street_address": ["exact"],
             "building__name": ["exact"],
         }
+        interfaces = (relay.Node,)
         max_complexity = 10
 
     completion_year = AnnotatedField(graphene.Int, ExtractYear("completion_date"))

--- a/tests/test_relay_node.py
+++ b/tests/test_relay_node.py
@@ -9,6 +9,25 @@ pytestmark = [
     pytest.mark.django_db,
 ]
 
+def test_global_relay_node(graphql_client):
+    apartment = ApartmentFactory.create(building__name="1")
+    global_id = to_global_id(str(ApartmentNode), apartment.pk)
+
+    query = """
+        query {
+          node(id: "%s") {
+            ... on ApartmentType {
+              building {
+                name
+              }
+            }
+          }
+        }
+    """ % (global_id,)
+
+    response = graphql_client(query)
+    assert response.no_errors, response.errors
+
 
 def test_relay__node(graphql_client):
     apartment = ApartmentFactory.create(building__name="1")


### PR DESCRIPTION
Hi @MrThearMan and @matti-lamppu

First of all, thank you for your awesome work on this project!
I'd like to report an issue that pops up when the global relay interface `Node` is used (see [docs](https://relay.dev/docs/guides/graphql-server-specification/#schema)):

Example query:
```gql
query {
  node(id: "%s") {
    ... on ApartmentType {
      building {
        name
      }
    }
  }
}
```
Causes:
```
  File "/home/christian/dev/graphene-django-query-optimizer/query_optimizer/ast.py", line 186, in handle_inline_fragment
    fragment_type = get_fragment_type(field_type, inline_fragment)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/christian/dev/graphene-django-query-optimizer/query_optimizer/ast.py", line 271, in get_fragment_type
    gen = (t for t in field_type.types if t.name == fragment_type_name)
```
It seems that a UnionType is expected (which knows about all the possible implementation `types`), but we have an InterfaceType instead. I figured i'd open this Issue/PR for potential feedback, while my colleague @winged and I will try to dig deeper and maybe suggest a potential fix.

Thank you in advance!