### PR TITLE
hotfix: allow to query relay node field without a fragment

### DIFF
--- a/query_optimizer/ast.py
+++ b/query_optimizer/ast.py
@@ -89,6 +89,9 @@ class GraphQLASTWalker:
         if issubclass(graphene_type, ObjectType):
             return self.handle_object_type(field_type, field_node)
 
+        if issubclass(graphene_type, AbstractNode):
+            return self.handle_abstract_node(field_type, field_node)
+
         msg = f"Unhandled graphene type: '{graphene_type}'"  # pragma: no cover
         raise OptimizerError(msg)  # pragma: no cover
 
@@ -107,6 +110,8 @@ class GraphQLASTWalker:
         if issubclass(graphene_type, DjangoObjectType):
             return self.handle_model_field(field_type, field_node, field_name)
         return self.handle_plain_object_type(field_type, field_node)
+
+    def handle_abstract_node(self, field_type: GrapheneObjectType, field_node: FieldNode) -> None: ...
 
     def handle_graphql_builtin(self, field_type: GrapheneObjectType, field_node: FieldNode) -> None: ...
 

--- a/query_optimizer/ast.py
+++ b/query_optimizer/ast.py
@@ -11,6 +11,7 @@ from graphene.relay.node import AbstractNode
 from graphene.types.definitions import GrapheneInterfaceType, GrapheneObjectType, GrapheneUnionType
 from graphene.utils.str_converters import to_snake_case
 from graphene_django import DjangoObjectType
+from graphene_django.registry import get_global_registry
 from graphql import (
     FieldNode,
     FragmentDefinitionNode,
@@ -111,7 +112,10 @@ class GraphQLASTWalker:
             return self.handle_model_field(field_type, field_node, field_name)
         return self.handle_plain_object_type(field_type, field_node)
 
-    def handle_abstract_node(self, field_type: GrapheneObjectType, field_node: FieldNode) -> None: ...
+    def handle_abstract_node(self, field_type: GrapheneObjectType, field_node: FieldNode) -> None:
+        graphene_type = get_global_registry().get_type_for_model(self.model._meta.concrete_model)
+        field_type = self.info.schema.get_type(graphene_type._meta.name)
+        return self.handle_object_type(field_type, field_node)
 
     def handle_graphql_builtin(self, field_type: GrapheneObjectType, field_node: FieldNode) -> None: ...
 

--- a/tests/test_relay_node.py
+++ b/tests/test_relay_node.py
@@ -40,6 +40,26 @@ def test_relay__global_node(graphql_client):
     assert response.content == {"building": {"name": "1"}}
 
 
+def test_relay__global_node_without_fragment(graphql_client):
+    apartment = ApartmentFactory.create(building__name="1")
+    global_id = to_global_id(str(ApartmentNode), apartment.pk)
+
+    query = """
+        query {
+          node(id: "%s") {
+            __typename
+            id
+          }
+        }
+    """ % (global_id,)
+
+    response = graphql_client(query)
+
+    assert response.no_errors, response.errors
+    assert response.queries.count == 1, response.queries.log
+    assert response.content == {"__typename": "ApartmentNode", "id": global_id}
+
+
 def test_relay__node(graphql_client):
     apartment = ApartmentFactory.create(building__name="1")
     global_id = to_global_id(str(ApartmentNode), apartment.pk)


### PR DESCRIPTION
[//]: # "Please read `CONTRIBUTING.md` before opening a pull request."

# Description
[//]: # "Describe the changes in this pull request here."

Queries with fields outside of the fragment, like:

```graphql
query MyQuery($id: ID!) {
  node(id: $id) {
    __typename
    id
    ... on MyFragment { name }
    ... on MyOtherFragment { name: title }
  }
}
```

fails with

```
OptimizerError: Unhandled graphene type: 'Node'
```

-----

Maybe there is a better way to solve this?

The issue seems to be around trying to figure out the Object Type for the queried field, but it is already known when `optimize_single` is called on `get_node`. The fix could be calling `handle_object_type` instead of the suggested `handle_abstract_node`, but for that we need the Object Type to be passed down the stack through `optimize_single`.

What are your thoughts? 